### PR TITLE
Hotfix/emails stamp v4

### DIFF
--- a/src/sw-sdk/Helpers/RequestHelper.cs
+++ b/src/sw-sdk/Helpers/RequestHelper.cs
@@ -36,8 +36,9 @@ namespace SW.Helpers
             Dictionary<string, string> headers = new Dictionary<string, string>() {
                     { "Authorization", "bearer " + service.Token }
                 };
-            if (email != null && Validation.ValidateEmailStamp(email))
+            if (email != null)
             {
+                Validation.ValidateEmailStamp(email);
                 headers.Add("email", email);
             }
             if (customId != null)

--- a/src/sw-sdk/Helpers/Validation.cs
+++ b/src/sw-sdk/Helpers/Validation.cs
@@ -54,16 +54,27 @@ namespace SW.Helpers
                 throw new ServicesException("Token Mal Formado");
             }
         }
-        internal static bool ValidateEmailStamp(string email)
+        internal static void ValidateEmailStamp(string email)
         {
+            string[] emails = email.Split(',');
+            if (emails.Count() == 0 || emails.Count() > 5)
+            {
+                throw new ServicesException("El listado de correos contiene más de 5 correos o está vacío.");
+            }
             try
             {
-                var addr = new System.Net.Mail.MailAddress(email);
-                return addr.Address == email;
+                emails.ToList().ForEach(e =>
+                {
+                    var addr = new System.Net.Mail.MailAddress(e);
+                    if (addr.Address != e)
+                    {
+                        throw new FormatException(); 
+                    }
+                });
             }
-            catch
+            catch (FormatException)
             {
-                return false;
+                throw new ServicesException("El formato de uno o más correos no es correcto.");
             }
         }
         internal static void ValidateEmail(string[] email)

--- a/src/sw-sdk/sw-sdk.csproj
+++ b/src/sw-sdk/sw-sdk.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>sw_sdk</RootNamespace>
-    <VersionPrefix>1.0.13.1</VersionPrefix>
+    <VersionPrefix>1.0.13.2</VersionPrefix>
     <AssemblyName>sw-sdk-netstandard</AssemblyName>
     <Title>SDK SW sapien®</Title>
     <Authors>SW sapien®</Authors>

--- a/test/sdk-test/Services/Pdf/Pdf_Test.cs
+++ b/test/sdk-test/Services/Pdf/Pdf_Test.cs
@@ -71,8 +71,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(String.Empty, build.b64Logo, PdfTemplates.cfdi40, null, true);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "400"));
-            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
+            Assert.True(String.Equals(response.Message, "500"));
+            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
         }
         /// <summary>
         /// Generar PDF, XML en B64, string B64 invalido.
@@ -101,8 +101,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(xml, build.b64Logo, PdfTemplates.cfdi40, null, true);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "400"));
-            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
+            Assert.True(String.Equals(response.Message, "500"));
+            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
         }
         /// <summary>
         /// Generar PDF, error XML vacio.
@@ -114,8 +114,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(String.Empty, build.b64Logo, PdfTemplates.cfdi40, null);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "400"));
-            Assert.True(String.Equals(response.MessageDetail, "Bad Request")); ;
+            Assert.True(String.Equals(response.Message, "500"));
+            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error")); ;
         }
         /// <summary>
         /// Generar PDF, XML no timbrado.
@@ -128,8 +128,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(xml, build.b64Logo, PdfTemplates.cfdi40, null);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "400"));
-            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
+            Assert.True(String.Equals(response.Message, "500"));
+            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
         }
         /// <summary>
         /// Generar PDF mediante token

--- a/test/sdk-test/Services/Pdf/Pdf_Test.cs
+++ b/test/sdk-test/Services/Pdf/Pdf_Test.cs
@@ -71,8 +71,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(String.Empty, build.b64Logo, PdfTemplates.cfdi40, null, true);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "500"));
-            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
+            Assert.True(String.Equals(response.Message, "400"));
+            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
         }
         /// <summary>
         /// Generar PDF, XML en B64, string B64 invalido.
@@ -101,8 +101,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(xml, build.b64Logo, PdfTemplates.cfdi40, null, true);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "500"));
-            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
+            Assert.True(String.Equals(response.Message, "400"));
+            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
         }
         /// <summary>
         /// Generar PDF, error XML vacio.
@@ -114,8 +114,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(String.Empty, build.b64Logo, PdfTemplates.cfdi40, null);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "500"));
-            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error")); ;
+            Assert.True(String.Equals(response.Message, "400"));
+            Assert.True(String.Equals(response.MessageDetail, "Bad Request")); ;
         }
         /// <summary>
         /// Generar PDF, XML no timbrado.
@@ -128,8 +128,8 @@ namespace sdk_test.Services.Pdf
             SW.Services.Pdf.Pdf pdf = new SW.Services.Pdf.Pdf(build.UrlApi, build.Token);
             var response = await pdf.GenerarPdfAsync(xml, build.b64Logo, PdfTemplates.cfdi40, null);
             CustomAssert.ErrorResponse(response);
-            Assert.True(String.Equals(response.Message, "500"));
-            Assert.True(String.Equals(response.MessageDetail, "Internal Server Error"));
+            Assert.True(String.Equals(response.Message, "400"));
+            Assert.True(String.Equals(response.MessageDetail, "Bad Request"));
         }
         /// <summary>
         /// Generar PDF mediante token

--- a/test/sdk-test/Services/Stamp/StampV4_Test.cs
+++ b/test/sdk-test/Services/Stamp/StampV4_Test.cs
@@ -258,6 +258,51 @@ namespace Test_SW.Services.Stamp_Test
             CustomAssert.ErrorResponse(response);
             Assert.True(!string.IsNullOrEmpty(response.Message), resultExpect);
         }
+        //Email
+        [Fact]
+        public async Task Stamp_Test_TimbrarV1Email_Succes()
+        {
+            var build = new BuildSettings();
+            StampV4 stamp = new StampV4(build.Url, build.User, build.Password);
+            var xml = GetXml(build);
+            var response = (StampResponseV1)await stamp.TimbrarV1Async(xml, "someemail@some.com");
+            CustomAssert.SuccessResponse(response, response.Data);
+            Assert.True(!string.IsNullOrEmpty(response.Data.Tfd), "El resultado Data.Tfd viene vacio.");
+        }
+        [Fact]
+        public async Task Stamp_Test_TimbrarV1MultiEmail_Succes()
+        {
+            var build = new BuildSettings();
+            StampV4 stamp = new StampV4(build.Url, build.User, build.Password);
+            var xml = GetXml(build);
+            var response = (StampResponseV1)await stamp.TimbrarV1Async(xml, "someemail1@some.com,someemail2@some.com");
+            CustomAssert.SuccessResponse(response, response.Data);
+            Assert.True(!string.IsNullOrEmpty(response.Data.Tfd), "El resultado Data.Tfd viene vacio.");
+        }
+        [Fact]
+        public async Task Stamp_Test_TimbrarV1MultiEmail_Error()
+        {
+            var resultExpect = "El formato de uno o más correos no es correcto.";
+            var build = new BuildSettings();
+            StampV4 stamp = new StampV4(build.Url, build.User, build.Password);
+            var xml = GetXml(build);
+            var response = (StampResponseV1)await stamp.TimbrarV1Async(xml, "someemail@some.com,someemailsome.co");
+            CustomAssert.ErrorResponse(response);
+            Assert.True(!string.IsNullOrEmpty(response.Message), resultExpect);
+        }
+        [Fact]
+        public async Task Stamp_Test_TimbrarV1MaxEmail_Error()
+        {
+            var resultExpect = "El listado de correos contiene más de 5 correos o está vacío.";
+            var build = new BuildSettings();
+            StampV4 stamp = new StampV4(build.Url, build.User, build.Password);
+            var xml = GetXml(build);
+            string emails = "someemail1@some.com,someemail2@some.com,someemail3@some.com,someemail4@some.com,someemail5@some.com,someemail6@some.com";
+            var response = (StampResponseV1)await stamp.TimbrarV1Async(xml, emails);
+            CustomAssert.ErrorResponse(response);
+            Assert.True(!string.IsNullOrEmpty(response.Message), resultExpect);
+        }
+
         private string GetXml(BuildSettings build, string fileName = null)
         {
             var xml = Encoding.UTF8.GetString(File.ReadAllBytes(String.Format("Resources/CFDI40/{0}", fileName ?? "cfdi40.xml")));


### PR DESCRIPTION
Se ajusta el servicio de timbradoV4 para permitir que se envíen hasta máximo 5 correos.
Se respeta el formato existente.